### PR TITLE
Add error handling for downloadDb JSON parsing

### DIFF
--- a/src/utils/database/database.js
+++ b/src/utils/database/database.js
@@ -36,10 +36,16 @@ const downloadDb = async (appId, token) => {
     body: new URLSearchParams(data),
   };
   let databaseUrl = await fetch('https://api.appdrag.com/CloudBackend.aspx', opts);
-  databaseUrl = await databaseUrl.json();
+  databaseUrl = await databaseUrl.text(); // First convert the stream object to text
+  try {
+    databaseUrl = JSON.parse(databaseUrl);
+  } catch (e) {
+    console.log(chalk.yellow(`Error parsing server response to json, attempting to retrieve backup of DB`));
+    console.log(chalk.gray("Server response:",databaseUrl));
+  }
   if (databaseUrl.status !== 'OK') {
-    await getAllDbVersions(appId, token);
-    return;
+      await getAllDbVersions(appId, token);
+      return;
   }
   databaseUrl = databaseUrl.url;
   let file = fs.createWriteStream(`${appId}_backup.sql`);


### PR DESCRIPTION
First consume and convert the Stream object returned from fetch to text, then parse JSON in a try/catch block. If it fails, log to console.